### PR TITLE
Added GraphQL integration.

### DIFF
--- a/__tests__/demo-graphql.js
+++ b/__tests__/demo-graphql.js
@@ -1,0 +1,118 @@
+const {astToOptions, astToPipeline} = require('sparrowql-graphql');
+const {buildSchema, parse, graphql} = require('graphql');
+
+testWithNCollections(3, 'demo', async (Blogs, Posts, Users) => {
+    const blogs = [
+        {_id: 0, ownerId: 3, topic: 'Best blog!'} // prettier ignore
+    ];
+
+    const posts = [
+        {_id: 0, authorId: 0, blogId: 0, title: 'Being fast for dummies'},
+        {_id: 1, authorId: 0, blogId: 0, title: 'Being declarative for dummies'},
+        {_id: 2, authorId: 1, blogId: 0, title: 'Amazing!'},
+        {_id: 3, authorId: 2, blogId: 0, title: 'A sparrow, really?'}
+    ];
+
+    const users = [
+        {_id: 0, name: 'SparrowQL', about: 'Declarative MongoDB aggregations'},
+        {_id: 1, name: 'Random #1', about: 'Node.js developer'},
+        {_id: 2, name: 'Random #2', about: 'Bird lover'},
+        {_id: 3, name: 'BlogOwner', about: 'Owner of the only blog here'}
+    ];
+
+    await Blogs.insertMany(blogs);
+    await Posts.insertMany(posts);
+    await Users.insertMany(users);
+
+    const schemaSource = `
+        directive @collection(name: String!) on OBJECT
+        directive @relationTo(local: String!, foreign: String!, as: String) on FIELD_DEFINITION
+
+        type Blog @collection(name: "Blogs") {
+            _id: ID!
+            owner: User! @relationTo(local: "ownerId", foreign: "_id", as: "Owners")
+            topic: String!
+        }
+
+        type Post @collection(name: "Posts") {
+            _id: ID!
+            author: User! @relationTo(local: "authorId", foreign: "_id", as: "Authors")
+            # "as" defaults to collection name
+            blog: Blog! @relationTo(local: "blogId", foreign: "_id")
+            title: String!
+        }
+
+        type User @collection(name: "Users") {
+            _id: ID!
+            about: String!
+            name: String!
+        }
+
+        type Query {
+            posts: [Post!]!
+        }
+    `;
+
+    const options = astToOptions(parse(schemaSource));
+    const order = (a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b));
+    options.collections.sort(order);
+    options.relations.sort(order);
+
+    expect(options).toEqual({
+        collections: ['Blogs', 'Posts', 'Users'],
+        relations: [
+            {foreign: '_id', from: 'Blogs', local: 'ownerId', to: 'Owners'},
+            {foreign: '_id', from: 'Posts', local: 'authorId', to: 'Authors'},
+            {foreign: '_id', from: 'Posts', local: 'blogId', to: 'Blogs'}
+        ],
+        typeMap: {
+            'Blog.owner': 'Owners',
+            'Post.author': 'Authors',
+            'Post.blog': 'Blogs',
+            'Query.posts': 'Posts'
+        }
+    });
+
+    const schema = buildSchema(schemaSource);
+
+    const resolver = {
+        posts(args, context, info) {
+            const pipeline = astToPipeline(info, {
+                ...options,
+                aliases: {
+                    Authors: Users.collectionName,
+                    Blogs: Blogs.collectionName,
+                    Posts: Posts.collectionName,
+                    Owners: Users.collectionName
+                },
+                start: 'Posts'
+            });
+
+            return Posts.aggregate(pipeline).toArray();
+        }
+    };
+
+    const evaluate = query => graphql(schema, query, resolver);
+
+    await expect(evaluate('{ posts { blog { topic } title } }')).resolves.toEqual({
+        data: {
+            posts: [
+                {blog: {topic: 'Best blog!'}, title: 'Being fast for dummies'},
+                {blog: {topic: 'Best blog!'}, title: 'Being declarative for dummies'},
+                {blog: {topic: 'Best blog!'}, title: 'Amazing!'},
+                {blog: {topic: 'Best blog!'}, title: 'A sparrow, really?'}
+            ]
+        }
+    });
+
+    await expect(evaluate('{ posts { author { name } blog { owner { name } } } }')).resolves.toEqual({
+        data: {
+            posts: [
+                {author: {name: 'SparrowQL'}, blog: {owner: {name: 'BlogOwner'}}},
+                {author: {name: 'SparrowQL'}, blog: {owner: {name: 'BlogOwner'}}},
+                {author: {name: 'Random #1'}, blog: {owner: {name: 'BlogOwner'}}},
+                {author: {name: 'Random #2'}, blog: {owner: {name: 'BlogOwner'}}}
+            ]
+        }
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4536,6 +4536,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graphql": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -5219,6 +5227,11 @@
       "requires": {
         "handlebars": "^4.0.3"
       }
+    },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "jest": {
       "version": "23.5.0",
@@ -7741,9 +7754,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-vazco": "1.0.0",
+    "graphql": "14.0.2",
     "jest": "23.5.0",
     "lerna": "3.4.3",
     "mongodb": "3.1.3",

--- a/packages/sparrowql-graphql/lib/graph.js
+++ b/packages/sparrowql-graphql/lib/graph.js
@@ -1,0 +1,126 @@
+const {visit} = require('graphql/language');
+
+const {build} = require('sparrowql');
+
+function extractType(type) {
+    return type.ofType ? extractType(type.ofType) : type;
+}
+
+function extractTypeAST(type) {
+    return type.kind === 'ListType' || type.kind === 'NonNullType' ? extractTypeAST(type.type) : type;
+}
+
+function astToOptions(schemaAST, {directiveCollection = 'collection', directiveRelation = 'relationTo'} = {}) {
+    // Local mappings.
+    const collection2type = {};
+    const type2collection = {};
+
+    // Standard options.
+    const collections = [];
+    const relations = [];
+    const typeMap = {};
+
+    visit(schemaAST, {
+        FieldDefinition(node) {
+            if (!node.directives || node.directives.length === 0) return false;
+            for (const directive of node.directives) {
+                if (directive.name.value !== directiveRelation) continue;
+
+                const relation = {
+                    foreign: null,
+                    from: collections[0],
+                    local: null,
+                    to: type2collection[node.type.type.name.value]
+                };
+
+                for (const {name, value} of directive.arguments) {
+                    if (name.value === 'as') relation.to = value.value;
+                    else if (name.value === 'foreign') relation.foreign = value.value;
+                    else if (name.value === 'local') relation.local = value.value;
+                }
+
+                relations.push(relation);
+                typeMap[`${collection2type[relation.from]}.${node.name.value}`] = relation.to;
+                break;
+            }
+
+            return false;
+        },
+        ObjectTypeDefinition(node) {
+            if (node.name.value === 'Query')
+                for (const field of node.fields)
+                    typeMap[`Query.${field.name.value}`] = type2collection[extractTypeAST(field.type).name.value];
+
+            if (!node.directives || node.directives.length === 0) return false;
+            for (const directive of node.directives) {
+                if (directive.name.value !== directiveCollection) continue;
+
+                for (const argument of directive.arguments) {
+                    if (argument.name.value !== 'name') continue;
+
+                    type2collection[node.name.value] = argument.value.value;
+                    collection2type[argument.value.value] = node.name.value;
+                    collections.unshift(argument.value.value);
+
+                    return undefined;
+                }
+            }
+
+            return false;
+        }
+    });
+
+    return {collections, relations, typeMap};
+}
+
+function astToPipeline(info, options) {
+    const scopes = [];
+    const inflateMap = {};
+    const projection = {};
+
+    const rootType = extractType(info.schema.getQueryType());
+    const extractPathType = path =>
+        path.reduce((node, field) => extractType(node.getFields()[field].type), rootType).name;
+
+    visit(info.operation, {
+        Field(node) {
+            if (node.selectionSet) {
+                scopes.push(node.name.value);
+            } else {
+                const field = node.name.value;
+                const scope = scopes[scopes.length - 1];
+                const path = scopes.concat(field);
+                const target = path.join('__SPARROWQL__');
+
+                const y = scopes.length === 1 ? [] : scopes.slice(0, -1);
+                const x = `${extractPathType(y)}.${scope}`;
+
+                projection[target] = `${options.typeMap[x]}.${field}`;
+
+                let position = inflateMap;
+                while (path.length > 1) {
+                    const part = path.shift();
+                    if (position[part] === undefined) {
+                        position[part] = {};
+                    }
+
+                    position = position[part];
+                }
+
+                position[path[0]] = `$${target}`;
+            }
+        },
+        SelectionSet: {
+            leave() {
+                scopes.pop();
+            }
+        }
+    });
+
+    return build({...options, projection}).concat({$project: inflateMap[info.fieldName]});
+}
+
+module.exports = {
+    astToOptions,
+    astToPipeline
+};

--- a/packages/sparrowql-graphql/lib/index.js
+++ b/packages/sparrowql-graphql/lib/index.js
@@ -1,0 +1,4 @@
+// prettier-ignore
+module.exports = Object.assign({},
+    require('./graph')
+);

--- a/packages/sparrowql-graphql/package-lock.json
+++ b/packages/sparrowql-graphql/package-lock.json
@@ -1,0 +1,21 @@
+{
+	"name": "sparrowql-graphql",
+	"version": "0.2.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"graphql": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+			"integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+			"requires": {
+				"iterall": "^1.2.2"
+			}
+		},
+		"iterall": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+		}
+	}
+}

--- a/packages/sparrowql-graphql/package.json
+++ b/packages/sparrowql-graphql/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sparrowql-graphql",
+  "version": "0.2.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "description": "GraphQL interface for SparrowQL.",
+  "repository": "https://github.com/vazco/sparrowql/tree/master/packages/sparrowql-graphql",
+  "bugs": "https://github.com/vazco/sparrowql/issues",
+  "keywords": [
+    "aggregate",
+    "declarative",
+    "graphql",
+    "mongodb"
+  ],
+  "dependencies": {
+    "graphql": "^14.0.0",
+    "sparrowql": "file:../sparrowql"
+  },
+  "engines": {
+    "node": ">=8"
+  }
+}


### PR DESCRIPTION
Finally, I've come up with an API idea on _how_ to integrate SparrowQL with GraphQL.

Long story short: there's a new `buildFromGraphQL(info, options)` function, that makes use of GraphQL `info` object. Options are the standard options, with two exceptions: one, `projection` is ignored, as it's build from the query, two, there's a new `typeMap: {[string]: string}`, which maps a field to a collection.

Demo and tests are in [`__tests__/demo-graphql.js`](https://github.com/vazco/sparrowql/blob/a55a51bff81f556df78c5c7ab0f0cabf229e6a26/__tests__/demo-graphql.js).

As I'm not sure about two things, and I'd love some feedback:
* Is the `typeMap` actually clear and named correctly? Maybe we could extract it from the schema, but I don't have any idea on how to define it in there in a convinient way.
* It introduces a dependency, but it's not marked in the `dependencies`, as it's _optional_ (as long as you are not using this function). I'd use `peerDependencies`, but it's still results in a warning. Maybe we should release a new package (but it's only a single function!)?

---

Background:
Same as the whole SparrowQL, the idea of integrating it with GraphQL popped out in an internal hackathon. We've done _something_, but the results were... Bad? Mostly, because you had to define the whole relations and mappings in your schema. It looked like this:

```graphql
type Customer @db(name: customers) {
  _id: ID!
  restaurants: [Restaurant!]! @relation(field: restaurantIds)
  restaurantIds: [ID!]!
  reservations: [Reservation!]! @reversedRelation(field: customerId)
}
```

It was definitely too verbose. After some time, and giving it some thoughts I have a new API idea. In short, we keep your schema as it is, but instead, we do parse the query and build a `projection` from it. The only _problem_ at the moment is that we don't track the types, so you have to provie the `typeMap`.

Also, thanks to @janowsiany, as he is the reason, why I didn't included the whole GraphQL integration in the first release, as it was _not so GraphQL_. :rocket: