### PR TITLE
Fixed pipeline build with a collection name being a prefix of the other.

### DIFF
--- a/__mongo__/environment.js
+++ b/__mongo__/environment.js
@@ -9,9 +9,11 @@ class MongoEnvironment extends NodeEnvironment {
         await setup();
         await super.setup();
 
-        this.global.testWithNCollections = (n, name, fn) => {
-            this.global.test(name, async () => {
-                const collections = Array.from({length: n}, () => global.__MONGO__.db.collection(uuid()));
+        this.global.testWithNCollections = (newCollections, testName, fn) => {
+            this.global.test(testName, async () => {
+                const collections = Array.from({length: newCollections.length || newCollections}, (_, index) =>
+                    global.__MONGO__.db.collection(newCollections[index] || uuid())
+                );
                 try {
                     await fn(...collections);
                 } finally {

--- a/__mongo__/environment.js
+++ b/__mongo__/environment.js
@@ -11,9 +11,10 @@ class MongoEnvironment extends NodeEnvironment {
 
         this.global.testWithNCollections = (newCollections, testName, fn) => {
             this.global.test(testName, async () => {
-                const collections = Array.from({length: newCollections.length || newCollections}, (_, index) =>
-                    global.__MONGO__.db.collection(newCollections[index] || uuid())
-                );
+                const db = global.__MONGO__.db;
+                const collections = Array.isArray(newCollections)
+                    ? newCollections.map(name => db.collection(name))
+                    : Array.from({length: newCollections}, () => db.collection(uuid()));
                 try {
                     await fn(...collections);
                 } finally {

--- a/__tests__/basics/limit.js
+++ b/__tests__/basics/limit.js
@@ -3,8 +3,8 @@ const {v1: uuid} = require('uuid');
 const {build} = require('sparrowql');
 
 describe('limit', () => {
-    testWithNCollections(1, 'should work', async collectionA => {
-        const docs = [{x: uuid(), y: uuid()}];
+    testWithNCollections(1, 'should properly return only one document', async collectionA => {
+        const docs = [{x: uuid(), y: uuid()}, {x: uuid(), y: uuid()}];
         await collectionA.insertMany(docs);
 
         const pipeline = build({
@@ -12,6 +12,6 @@ describe('limit', () => {
             start: collectionA.collectionName
         });
 
-        await expect(collectionA.aggregate(pipeline).toArray()).resolves.toEqual(docs);
+        await expect(collectionA.aggregate(pipeline).toArray()).resolves.toEqual([docs[0]]);
     });
 });

--- a/packages/sparrowql-graphql/package-lock.json
+++ b/packages/sparrowql-graphql/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "sparrowql-graphql",
-	"version": "0.2.0",
+	"version": "0.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/sparrowql/lib/build.js
+++ b/packages/sparrowql/lib/build.js
@@ -253,7 +253,7 @@ const translateOperators = {
     relation: (start, step) => [
         {
             $lookup: {
-                as: getNameRelative(start, step.relation.to, false),
+                as: getNameRelative(start, step.relation.to, false, true),
                 foreignField: step.relation.foreign,
                 from: step.relation.toAlias,
                 localField: step.relation.local
@@ -261,7 +261,7 @@ const translateOperators = {
         },
         {
             $unwind: {
-                path: getNameRelative(start, step.relation.to, true),
+                path: getNameRelative(start, step.relation.to, true, true),
                 preserveNullAndEmptyArrays: true
             }
         }

--- a/packages/sparrowql/lib/build.js
+++ b/packages/sparrowql/lib/build.js
@@ -253,7 +253,7 @@ const translateOperators = {
     relation: (start, step) => [
         {
             $lookup: {
-                as: getNameRelative(start, step.relation.to, false, true),
+                as: getNameRelative(start, step.relation.to, false),
                 foreignField: step.relation.foreign,
                 from: step.relation.toAlias,
                 localField: step.relation.local
@@ -261,7 +261,7 @@ const translateOperators = {
         },
         {
             $unwind: {
-                path: getNameRelative(start, step.relation.to, true, true),
+                path: getNameRelative(start, step.relation.to, true),
                 preserveNullAndEmptyArrays: true
             }
         }

--- a/packages/sparrowql/lib/utils.js
+++ b/packages/sparrowql/lib/utils.js
@@ -54,7 +54,7 @@ function getNameCollection(name) {
     return name.split('.', 2)[0];
 }
 
-function getNameRelative(prefix, name, isPath) {
+function getNameRelative(prefix, name, isPath, isRelation = false) {
     if (name === 0 || name === 1) return name;
     if (typeof name === 'object') return name;
     if (isOperator(name)) return name;
@@ -63,7 +63,7 @@ function getNameRelative(prefix, name, isPath) {
             .split('.')
             .slice(1)
             .join('.');
-    } else if (name.startsWith(prefix)) {
+    } else if (!isRelation && name.startsWith(prefix)) {
         name = name.replace(prefix, '');
     } else {
         name = `${PREFIX_JOINED}${name}`;

--- a/packages/sparrowql/lib/utils.js
+++ b/packages/sparrowql/lib/utils.js
@@ -54,7 +54,7 @@ function getNameCollection(name) {
     return name.split('.', 2)[0];
 }
 
-function getNameRelative(prefix, name, isPath, isRelation = false) {
+function getNameRelative(prefix, name, isPath) {
     if (name === 0 || name === 1) return name;
     if (typeof name === 'object') return name;
     if (isOperator(name)) return name;
@@ -63,7 +63,7 @@ function getNameRelative(prefix, name, isPath, isRelation = false) {
             .split('.')
             .slice(1)
             .join('.');
-    } else if (!isRelation && name.startsWith(prefix)) {
+    } else if (name.startsWith(prefix.replace(/\.?$/, '.'))) {
         name = name.replace(prefix, '');
     } else {
         name = `${PREFIX_JOINED}${name}`;


### PR DESCRIPTION
Also in this PR:
- Fixed limit test name being incorrect and improved it's logic to actually test the `limit` feature.
- `testWithNCollections` function's first argument can now be an array of strings to generate collections with a fixed name or a number.
- Updated `package-lock.json` in `sparrowql-graphql` package.